### PR TITLE
feat: add yayamlls 0.1.11

### DIFF
--- a/yayamlls/.SRCINFO
+++ b/yayamlls/.SRCINFO
@@ -1,0 +1,12 @@
+pkgbase = yayamlls
+	pkgdesc = Go YAML language server
+	pkgver = 0.1.11
+	pkgrel = 1
+	url = https://github.com/home-operations/yayamlls
+	arch = x86_64
+	license = MIT
+	options = !strip
+	source = yayamlls-0.1.11-linux-amd64.tar.gz::https://github.com/home-operations/yayamlls/releases/download/0.1.11/yayamlls_0.1.11_linux_amd64.tar.gz
+	sha256sums = 75dc9a8e96352fb23738242ea53c9e890bab75f3d0ab572ced856cc15458627f
+
+pkgname = yayamlls

--- a/yayamlls/PKGBUILD
+++ b/yayamlls/PKGBUILD
@@ -1,0 +1,17 @@
+# Maintainer: Antoine Bertin <ant.bertin@gmail.com>
+
+pkgname=yayamlls
+pkgver=0.1.11 # renovate: datasource=github-releases depName=home-operations/yayamlls
+pkgrel=1
+pkgdesc="Go YAML language server"
+arch=(x86_64)
+url=https://github.com/home-operations/yayamlls
+license=(MIT)
+options=(!strip)
+source=("$pkgname-$pkgver-linux-amd64.tar.gz::$url/releases/download/$pkgver/${pkgname}_${pkgver}_linux_amd64.tar.gz")
+sha256sums=('75dc9a8e96352fb23738242ea53c9e890bab75f3d0ab572ced856cc15458627f')
+
+package() {
+  install -Dm755 yayamlls "$pkgdir/usr/bin/yayamlls"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
## Summary

- Add `yayamlls` — Go YAML language server from [home-operations/yayamlls](https://github.com/home-operations/yayamlls)
- Pre-built x86_64 binary package (v0.1.11)
- Renovate annotation for automatic version updates

## Test plan

- [ ] CI builds and installs package successfully
- [ ] `yayamlls --version` outputs `0.1.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)